### PR TITLE
Add option validation for commands

### DIFF
--- a/bind_urfave.go
+++ b/bind_urfave.go
@@ -44,6 +44,10 @@ func (c *node) toUrfaveCommand() *cli.Command {
 				if err := c.parsePositionalArgs(args); err != nil {
 					return err
 				}
+				// Validate options if command doesn't implement Validator
+				if err := c.validateOptions(); err != nil {
+					return err
+				}
 				// Call the UrfaveCommand's Run method directly
 				return urfaveCmd.Run(ctx, cliCmd)
 			}
@@ -58,6 +62,10 @@ func (c *node) toUrfaveCommand() *cli.Command {
 				// Parse positional arguments
 				args := cliCmd.Args().Slice()
 				if err := c.parsePositionalArgs(args); err != nil {
+					return err
+				}
+				// Validate options if command doesn't implement Validator
+				if err := c.validateOptions(); err != nil {
 					return err
 				}
 				// Call the original run function with nil cobra command since we're in urfave context


### PR DESCRIPTION
…nterface

This change adds the ability to validate individual options on commands when the command itself doesn't implement the Validator interface. Previously, the Validator interface was only checked at the command level.

Changes:
- Added validateOptions() method to check each option that implements Validator
- Integrated validation into both Cobra and Urfave bindings
- Validation runs after parsing but before command execution
- If the command implements Validator, option validation is skipped
- Added comprehensive tests for both Cobra and Urfave bindings

The validation respects the following behavior:
1. If command doesn't implement Validator: validate each option individually
2. If command implements Validator: skip individual option validation
3. Validation errors are properly returned with descriptive messages